### PR TITLE
Add texture target logging in XML

### DIFF
--- a/Bin/XSL/gliIntercept_DHTML2.xsl
+++ b/Bin/XSL/gliIntercept_DHTML2.xsl
@@ -459,7 +459,7 @@
 <!-- Tex Stage processing -->
 <!-- ========================================================================== -->
 
-<xsl:template match="TEXSTAGE">(<xsl:value-of select="@number"/>,<xsl:apply-templates select="IMAGE"/>)
+<xsl:template match="TEXSTAGE">(<xsl:value-of select="@target"/>,<xsl:value-of select="@number"/>,<xsl:apply-templates select="IMAGE"/>)
 </xsl:template>
 
 

--- a/Src/MainLib/ImageManager.cpp
+++ b/Src/MainLib/ImageManager.cpp
@@ -34,42 +34,41 @@ pBufferBound(false)
 
 ///////////////////////////////////////////////////////////////////////////////
 //
+const char* ImageData::GetTextureShortString(GLenum glType)
+{
+  switch (glType)
+  {
+    case(GL_TEXTURE_1D):
+      return "1D";
+    case(GL_TEXTURE_2D):
+      return "2D";
+    case(GL_TEXTURE_3D):
+      return "3D";
+    case(GL_TEXTURE_CUBE_MAP):
+      return "CUBE";
+    case(GL_TEXTURE_RECTANGLE):
+      return "RECT";
+    case(GL_TEXTURE_1D_ARRAY):
+      return "1D_ARRAY";
+    case(GL_TEXTURE_2D_ARRAY):
+      return "2D_ARRAY";
+    case(GL_TEXTURE_BUFFER):
+      return "TEX_BUFFER";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+//
 bool ImageData::GetUniqueFileName(string &retString) const
 {
   //Set the initial image name
   retString = "Image_";
 
   //Append the image type
-  switch(glType)
-  {
-    case(GL_TEXTURE_1D):
-      retString = retString + "1D_";
-      break;
-    case(GL_TEXTURE_2D):
-      retString = retString + "2D_";
-      break;
-    case(GL_TEXTURE_3D):
-      retString = retString + "3D_";
-      break;
-    case(GL_TEXTURE_CUBE_MAP):
-      retString = retString + "CUBE_";
-      break;
-    case(GL_TEXTURE_RECTANGLE):
-      retString = retString + "NVRECT_";
-      break;
-    case(GL_TEXTURE_1D_ARRAY):
-      retString = retString + "1D_ARRAY_";
-      break;
-    case(GL_TEXTURE_2D_ARRAY):
-      retString = retString + "2D_ARRAY_";
-      break;
-    case(GL_TEXTURE_BUFFER):
-      retString = retString + "TEX_BUFFER_";
-      break;
-    default:
-      retString = retString + "UNKNOWN_";
-      break;
-  }
+  retString += GetTextureShortString(glType);
+  retString += "_";
 
   //Add an extra flag for p-buffers
   if(IsPBufferBound())

--- a/Src/MainLib/ImageManager.h
+++ b/Src/MainLib/ImageManager.h
@@ -147,6 +147,18 @@ public:
 
   //@
   //  Summary:
+  //    To get a string identifying the texture type
+  //
+  //  Parameters:
+  //    glType  - The type of texture, e.g. GL_TEXTURE_2D
+  //
+  //  Returns:
+  //    A c-string, e.g. "2D"
+  //
+  static const char* GetTextureShortString(GLenum glType);
+
+  //@
+  //  Summary:
   //    To get a unique texture filename (including type,textureID and savecount)
   //    without any extension. 
   //  

--- a/Src/MainLib/InterceptImage.cpp
+++ b/Src/MainLib/InterceptImage.cpp
@@ -1567,6 +1567,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
       BoundTexture newBoundTexture;
       newBoundTexture.texID = texID;
       newBoundTexture.texStage = t;
+      newBoundTexture.texTarget = GL_TEXTURE_1D;
       retArray.push_back(newBoundTexture);
     }
 
@@ -1577,6 +1578,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
       BoundTexture newBoundTexture;
       newBoundTexture.texID = texID;
       newBoundTexture.texStage = t;
+      newBoundTexture.texTarget = GL_TEXTURE_2D;
       retArray.push_back(newBoundTexture);
     }
 
@@ -1589,6 +1591,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_RECTANGLE;
         retArray.push_back(newBoundTexture);
       }
     }
@@ -1602,6 +1605,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_3D;
         retArray.push_back(newBoundTexture);
       }
     }
@@ -1615,6 +1619,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_CUBE_MAP;
         retArray.push_back(newBoundTexture);
       }
     }
@@ -1627,6 +1632,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_1D_ARRAY;
         retArray.push_back(newBoundTexture);
       }
     }
@@ -1639,6 +1645,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_2D_ARRAY;
         retArray.push_back(newBoundTexture);
       }
     }
@@ -1651,6 +1658,7 @@ void InterceptImage::GetBoundTextures(BoundTextureArray &retArray)
         BoundTexture newBoundTexture;
         newBoundTexture.texID = texID;
         newBoundTexture.texStage = t;
+        newBoundTexture.texTarget = GL_TEXTURE_BUFFER;
         retArray.push_back(newBoundTexture);
       }
     }

--- a/Src/MainLib/InterceptImage.h
+++ b/Src/MainLib/InterceptImage.h
@@ -32,6 +32,7 @@ struct BoundTexture
 {
   uint texID;        // The texture ID that is bound            
   uint texStage;     // The stage the ID is bound to
+  uint texTarget;    // The target the ID is bound to
 };
 
 typedef vector<BoundTexture> BoundTextureArray;

--- a/Src/MainLib/InterceptLogXML.cpp
+++ b/Src/MainLib/InterceptLogXML.cpp
@@ -241,7 +241,7 @@ void InterceptLogXML::LogFunctionPre(const FunctionData *funcData,uint index, co
         //Loop for all textures and log the stage and texture number
         for(uint i=0;i<boundTextures.size();i++)
         {
-          fprintf(logFile,"<TEXSTAGE number=\"%u\">",boundTextures[i].texStage);
+          fprintf(logFile,"<TEXSTAGE number=\"%u\" target=\"%s\">",boundTextures[i].texStage, ImageData::GetTextureShortString(boundTextures[i].texTarget));
           AddImageTag(boundTextures[i].texID);
           fprintf(logFile,"</TEXSTAGE>");
         }


### PR DESCRIPTION
This PR adds display of texture target for textures that are dumped before a drawcall.

![image](https://user-images.githubusercontent.com/23078999/161966521-f6cc36f9-c19e-4e0b-85d8-94c10a5b1461.png)
