### PR TITLE
Add FullScreen option to LogFrame

### DIFF
--- a/Bin/MainLib/gliConfig.ini
+++ b/Bin/MainLib/gliConfig.ini
@@ -300,6 +300,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -348,6 +352,7 @@ FrameLog
 {
   LogEnabled = False;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/MainLib/gliConfig_Definition.ini
+++ b/Bin/MainLib/gliConfig_Definition.ini
@@ -284,6 +284,12 @@ FrameLog
     Comment = "The image format to save the frame buffer in. Current options are TGA,PNG, and JPG. (see ImageLog::SaveFormats for a decription of the formats)";
   }
 
+  FullScreen = (Boolean);
+  {
+    DefaultValue = False;
+    Comment = "Enables logging the entire framebuffer on render calls. If disabled, the dumped image will be framebuffer constrained by viewport set by glViewport() by the application. Currently Windows-only - Linux will ignore this flag.";
+  }
+
   FrameIcon
   {
     Enabled = (Boolean);

--- a/Bin/Profiles/gliConfig.xni
+++ b/Bin/Profiles/gliConfig.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = False;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_AuthorStd.xni
+++ b/Bin/Profiles/gliConfig_AuthorStd.xni
@@ -310,6 +310,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -358,6 +362,7 @@ FrameLog
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_DebugContext.xni
+++ b/Bin/Profiles/gliConfig_DebugContext.xni
@@ -307,6 +307,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -355,6 +359,7 @@ FrameLog
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_ExtOverride.xni
+++ b/Bin/Profiles/gliConfig_ExtOverride.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = False;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_FreeCam.xni
+++ b/Bin/Profiles/gliConfig_FreeCam.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = False;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_FullDebug.xni
+++ b/Bin/Profiles/gliConfig_FullDebug.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = False;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_ShaderEdit.xni
+++ b/Bin/Profiles/gliConfig_ShaderEdit.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/gliConfig_XMLFrame.xni
+++ b/Bin/Profiles/gliConfig_XMLFrame.xni
@@ -309,6 +309,10 @@ DisplayListLog
 //  SaveFormat    - The image format to save the frame buffer in. Current options are TGA,PNG, and JPG.
 //                  (see ImageLog::SaveFormats for a decription of the formats)
 //
+//  FullScreen    - Enables logging the entire framebuffer on render calls. If disabled, the dumped image
+//                  will be framebuffer constrained by viewport set by glViewport() by the application.
+//                  Currently Windows-only - Linux will ignore this flag.
+//
 //  FrameIcon->Enabled - This enables saving a icon version of all images saved. (useful in XML browser viewing)
 //
 //  FrameIcon->SaveFormat - The format of the save icon images (TGA,PNG or JPG)
@@ -357,6 +361,7 @@ FrameLog
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
 
   FrameIcon
   {

--- a/Bin/Profiles/test.xni
+++ b/Bin/Profiles/test.xni
@@ -63,6 +63,7 @@ FrameLog;
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
   ColorBufferLog = (pre,post,diff);
   StencilColors = (0,0xFF000000,1,0xFFFF0000,2,0xFFFFFF00,3,0xFF0000FF,4,0xFF00FFFF,5,0xFFFF00FF,6,0xFF80FFFF,7,0xFFFFFFFF);
   FrameIcon;

--- a/Bin/Profiles/test2.xni
+++ b/Bin/Profiles/test2.xni
@@ -61,6 +61,7 @@ FrameLog;
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
   ColorBufferLog = (pre,post,diff);
   StencilColors = (0,0xFF000000,1,0xFFFF0000,2,0xFFFFFF00,3,0xFF0000FF,4,0xFF00FFFF,5,0xFFFF00FF,6,0xFF80FFFF,7,0xFFFFFFFF);
   FrameIcon;

--- a/Bin/Profiles/test3.xni
+++ b/Bin/Profiles/test3.xni
@@ -63,6 +63,7 @@ FrameLog;
 {
   LogEnabled = True;
   SaveFormat = JPG;
+  FullScreen = False;
   ColorBufferLog = (pre,post,diff);
   StencilColors = (0,0xFF000000,1,0xFFFF0000,2,0xFFFFFF00,3,0xFF0000FF,4,0xFF00FFFF,5,0xFFFF00FF,6,0xFF80FFFF,7,0xFFFFFFFF);
   FrameIcon;

--- a/Src/MainLib/ConfigData.cpp
+++ b/Src/MainLib/ConfigData.cpp
@@ -668,6 +668,12 @@ void ConfigData::ReadFrameConfigData(ConfigParser &parser)
     GetImageFormat(frameTestToken, frameImageFormat);
   }
 
+  // Get fullscreen flag
+  frameTestToken = frameLogToken->GetChildToken("FullScreen");
+  if (frameTestToken)
+  {
+      frameTestToken->Get(frameFullScreen);
+  }
 
   //Get if icon frame buffer saving is enabled
   const ConfigToken *frameIconToken = frameLogToken->GetChildToken("FrameIcon");

--- a/Src/MainLib/ConfigData.cpp
+++ b/Src/MainLib/ConfigData.cpp
@@ -70,6 +70,7 @@ shaderLogUniformsPreRender(false),
 displayListLogEnabled(false),
 
 frameLogEnabled(false),
+frameFullScreen(false),
 frameImageFormat("jpg"),
 framePreColorSave(false),
 framePostColorSave(false),

--- a/Src/MainLib/ConfigData.h
+++ b/Src/MainLib/ConfigData.h
@@ -93,6 +93,7 @@ public:
 
 
   bool frameLogEnabled;                           // Flag to indicate if the frame log is enabled
+  bool frameFullScreen;                           // Flag to indicate if entire framebuffer should be saved
   vector<string> frameAdditionalRenderCalls;      // Additional functions for which to dump framebuffer
 
   string frameImageFormat;                        // The format to save frame images in.

--- a/Src/MainLib/InterceptFrame.cpp
+++ b/Src/MainLib/InterceptFrame.cpp
@@ -166,6 +166,8 @@ iglBindBuffer(NULL),
 iglGetFramebufferAttachmentParameteriv(NULL),
 iglBindFramebuffer(NULL),
 iglGetTexLevelParameteriv(NULL),
+iglGetRenderbufferParameteriv(NULL),
+iglBindRenderbuffer(NULL),
 
 depthSaveData(GL_DEPTH_COMPONENT, configData.framePreDepthSave,configData.framePostDepthSave,configData.frameDiffDepthSave),
 stencilSaveData(GL_STENCIL_INDEX, configData.framePreStencilSave,configData.framePostStencilSave,configData.frameDiffStencilSave),

--- a/Src/MainLib/InterceptFrame.cpp
+++ b/Src/MainLib/InterceptFrame.cpp
@@ -958,8 +958,8 @@ void InterceptFrame::GetBufferViewSize(GLenum bufType, uint bufferCount, GLint v
         iglGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &textureName);
 
         GLint oldBinding;
-        GLV.glBindTexture(GL_TEXTURE_2D, textureName);
         GLV.glGetIntegerv(GL_TEXTURE_BINDING_2D, &oldBinding);
+        GLV.glBindTexture(GL_TEXTURE_2D, textureName);
         iglGetTexLevelParameteriv(GL_TEXTURE_2D, mipLevel, GL_TEXTURE_WIDTH, &viewSize[2]);
         iglGetTexLevelParameteriv(GL_TEXTURE_2D, mipLevel, GL_TEXTURE_HEIGHT, &viewSize[3]);
         GLV.glBindTexture(GL_TEXTURE_2D, oldBinding);

--- a/Src/MainLib/InterceptFrame.cpp
+++ b/Src/MainLib/InterceptFrame.cpp
@@ -10,10 +10,6 @@
 #include "ImageSaveManager.h"
 #include "MovieMaker.h"
 
-#ifdef GLI_BUILD_WINDOWS
-#include <Windows.h>
-#endif
-
 //The real OpenGL driver
 extern GLCoreDriver GLV;
 extern WGLDriver    GLW;
@@ -169,6 +165,7 @@ iconExtension(configData.frameIconImageFormat),
 iglBindBuffer(NULL),
 iglGetFramebufferAttachmentParameteriv(NULL),
 iglBindFramebuffer(NULL),
+iglGetTexLevelParameteriv(NULL),
 
 depthSaveData(GL_DEPTH_COMPONENT, configData.framePreDepthSave,configData.framePostDepthSave,configData.frameDiffDepthSave),
 stencilSaveData(GL_STENCIL_INDEX, configData.framePreStencilSave,configData.framePostStencilSave,configData.frameDiffStencilSave),
@@ -328,6 +325,9 @@ bool InterceptFrame::Init()
     iglBindFramebuffer = (void (GLAPIENTRY *)(GLenum, GLuint))GLW.glGetProcAddress("glBindFramebuffer");
   }
 
+  iglGetTexLevelParameteriv = GLV_Builtin.glGetTexLevelParameteriv;
+  iglGetRenderbufferParameteriv = (void (GLAPIENTRY*)(GLenum, GLenum, GLint*))GLW.glGetProcAddress("glGetRenderbufferParameteriv");
+  iglBindRenderbuffer = (void (GLAPIENTRY*)(GLenum, GLuint))GLW.glGetProcAddress("glBindRenderbuffer");
   return true;
 }
 
@@ -910,33 +910,76 @@ bool InterceptFrame::IsBufferReadable(GLenum bufType, uint bufferCount) const
 
 ///////////////////////////////////////////////////////////////////////////////
 //
-void InterceptFrame::GetBufferViewSize(GLint viewSize[4]) const
+void InterceptFrame::GetBufferViewSize(GLenum bufType, uint bufferCount, GLint viewSize[4]) const
 {
-#ifdef GLI_BUILD_WINDOWS
+  viewSize[0] = 0;
+  viewSize[1] = 0;
+
   if (this->fullscreen)
   {
-      GLint fboId = 0;
-      GLV.glGetIntegerv(GL_READ_FRAMEBUFFER_BINDING, &fboId);
-      if (fboId == 0)
+    GLint fboId = 0;
+    if (extensionFBO) {
+      GLV.glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING, &fboId);
+    }
+    if (fboId == 0)
+    {
+      // Default framebuffer, get view size from window
+#ifdef GLI_BUILD_WINDOWS
+      HDC hdc = GLW.wglGetCurrentDC();
+      HWND hwnd = WindowFromDC(hdc);
+      if (hwnd != nullptr)
       {
-          HDC hdc = GLW.wglGetCurrentDC();
-          HWND hwnd = WindowFromDC(hdc);
-          if (hwnd != nullptr)
-          {
-              RECT clientRect{};
-              if (GetClientRect(hwnd, &clientRect))
-              {
-                  viewSize[0] = 0;
-                  viewSize[1] = 0;
-                  viewSize[2] = clientRect.right - clientRect.left;
-                  viewSize[3] = clientRect.bottom - clientRect.top;
-                  return;
-              }
-          }
+        RECT clientRect{};
+        if (GetClientRect(hwnd, &clientRect))
+        {
+          viewSize[2] = clientRect.right - clientRect.left;
+          viewSize[3] = clientRect.bottom - clientRect.top;
+          return;
+        }
       }
-  }
 #endif
+    }
+    else if(iglGetFramebufferAttachmentParameteriv)
+    {
+      // FBO created by application
+      GLenum attachment = (bufType == GL_RGBA) ? GL_COLOR_ATTACHMENT0 + bufferCount :
+                          (bufType == GL_DEPTH_COMPONENT) ? GL_DEPTH_ATTACHMENT :
+                          GL_STENCIL_ATTACHMENT;
+      GLint objectType = GL_NONE;
+      iglGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_TYPE, &objectType);
+      if (objectType == GL_TEXTURE && iglGetTexLevelParameteriv)
+      {
+        GLint mipLevel = 0;
+        iglGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_LEVEL, &mipLevel);
 
+        GLint textureName = 0;
+        iglGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &textureName);
+
+        GLint oldBinding;
+        GLV.glBindTexture(GL_TEXTURE_2D, textureName);
+        GLV.glGetIntegerv(GL_TEXTURE_BINDING_2D, &oldBinding);
+        iglGetTexLevelParameteriv(GL_TEXTURE_2D, mipLevel, GL_TEXTURE_WIDTH, &viewSize[2]);
+        iglGetTexLevelParameteriv(GL_TEXTURE_2D, mipLevel, GL_TEXTURE_HEIGHT, &viewSize[3]);
+        GLV.glBindTexture(GL_TEXTURE_2D, oldBinding);
+        return;
+      }
+      else if (objectType == GL_RENDERBUFFER && iglGetRenderbufferParameteriv && iglBindRenderbuffer)
+      {
+        GLint renderbufferName = 0;
+        iglGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER, attachment, GL_FRAMEBUFFER_ATTACHMENT_OBJECT_NAME, &renderbufferName);
+
+        GLint oldBinding;
+        GLV.glGetIntegerv(GL_RENDERBUFFER_BINDING, &oldBinding);
+        iglBindRenderbuffer(GL_RENDERBUFFER, renderbufferName);
+        iglGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &viewSize[2]);
+        iglGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_HEIGHT, &viewSize[3]);
+        iglBindRenderbuffer(GL_RENDERBUFFER, oldBinding);
+        return;
+      }
+    }
+  }
+
+  // Fallback to GL_VIEWPORT-based approach
   GLV.glGetIntegerv(GL_VIEWPORT, &viewSize[0]);
 }
 
@@ -946,7 +989,7 @@ corona::Image *InterceptFrame::GetBuffer(GLenum bufType, uint bufferCount) const
 {
   //Get the size of the viewport
   GLint viewSize[4];
-  GetBufferViewSize(viewSize);
+  GetBufferViewSize(bufType, bufferCount, viewSize);
 
   //If the viewport does not have a size, return NULL
   if(viewSize[2] == 0 || viewSize[3] == 0)

--- a/Src/MainLib/InterceptFrame.h
+++ b/Src/MainLib/InterceptFrame.h
@@ -188,6 +188,8 @@ protected:
   bool      extensionPBO;                         // Flag if the PBO extension is supported 
   bool      extensionFBO;                         // Flag if the FBO extension is supported (ARB or core version)
 
+  bool      fullscreen;                           // Flag if entire framebuffer is saved
+
   GLint     numDrawBuffers;                       // The number of draw buffers in use
 
   string    imageExtension;                       // The extension of the file format to savine images in (ie jpg/tga/png)  
@@ -308,6 +310,15 @@ protected:
   //    saveNamesIcon - The pre/post/diff icon file names to be assigned when saving data out.
   //
   void GetBufferDataPost(SaveFrameData *bufferData, string saveNames[FIDT_MAX], string saveNamesIcon[FIDT_MAX]) const;
+
+  //@
+  //  Summary:
+  //    To query view size of the framebuffer to save.
+  //
+  //  Parameters:
+  //    viewSize - array with four elements - x offset, y offset, width and height
+  //
+  void GetBufferViewSize(GLint viewSize[4]) const;
 
   //@
   //  Summary:

--- a/Src/MainLib/InterceptFrame.h
+++ b/Src/MainLib/InterceptFrame.h
@@ -207,6 +207,9 @@ protected:
   void (GLAPIENTRY *iglBindBuffer) (GLenum target, GLuint buffer); //PBO buffer setting entry point
   void (GLAPIENTRY *iglGetFramebufferAttachmentParameteriv) (GLenum target, GLenum attachment, GLenum pname, GLint *params); //OGL3.0/ FBO Entry point
   void (GLAPIENTRY *iglBindFramebuffer) (GLenum target, GLuint framebuffer);
+  void (GLAPIENTRY *iglGetTexLevelParameteriv) (GLenum target, GLint level, GLenum pname, GLint* params);
+  void (GLAPIENTRY *iglGetRenderbufferParameteriv) (GLenum target, GLenum pname, GLint* params);
+  void (GLAPIENTRY *iglBindRenderbuffer) (GLenum target, GLuint renderbuffer);
 
 
   //Structure to store the results of the frame data
@@ -316,9 +319,13 @@ protected:
   //    To query view size of the framebuffer to save.
   //
   //  Parameters:
+  //    bufType  - The buffer type to get. (ie GL_RGBA, GL_DEPTH_COMPONENT)
+  //
+  //    bufferCount - The index of the buffer type (ie there can be multiple
+  //                  color buffers)
   //    viewSize - array with four elements - x offset, y offset, width and height
   //
-  void GetBufferViewSize(GLint viewSize[4]) const;
+  void GetBufferViewSize(GLenum bufType, uint bufferCount, GLint viewSize[4]) const;
 
   //@
   //  Summary:


### PR DESCRIPTION
By default the saved framebuffers are constrained to OpenGL viewport.
It is often more comfortable to look at the entire buffer, which can
be enabled by setting FullScreen to True.

I'm leaving it OFF by default, to not disrupt well known default 
behaviour of this tool.